### PR TITLE
Sort expanded hostlist numerically

### DIFF
--- a/pkg/ghostlist/ghostlist.go
+++ b/pkg/ghostlist/ghostlist.go
@@ -200,11 +200,7 @@ func ExpandHostList(hostlist string) ([]string, error) {
 	results = removeDups(results)
 
 	// sort
-	err := sortHostlist(&results)
-
-	if err != nil {
-		return results, err
-	}
+	sortHostlist(&results)
 
 	return results, nil
 }

--- a/pkg/ghostlist/sorting.go
+++ b/pkg/ghostlist/sorting.go
@@ -1,17 +1,52 @@
 package ghostlist
 
 import (
-    "sort"
+	"sort"
+	"strconv"
+	"unicode"
 )
 
-/*
-func (s *sortListT) Sort() {
-
+func nextHostSpan(s string) (remainder string, span string, n bool) {
+	if s == "" {
+		return
+	}
+	for i, r := range s {
+		if i == 0 {
+			n = unicode.IsNumber(r)
+		} else if n != unicode.IsNumber(r) {
+			return s[i:], s[:i], n
+		}
+	}
+	return "", s, n
 }
-*/
 
-func sortHostlist(hostlist *[]string) error {
-	sort.Strings(*hostlist)
+func sortHost(s1, s2 string) bool {
+	for {
+		var sp1, sp2 string
+		var i, j bool
+		s1, sp1, i = nextHostSpan(s1)
+		s2, sp2, j = nextHostSpan(s2)
+		if sp1 == "" && sp2 == "" {
+			return false
+		}
+		if i && j {
+			if n1, err := strconv.ParseUint(sp1, 10, 64); err == nil {
+				if n2, err := strconv.ParseUint(sp2, 10, 64); err == nil {
+					if n1 != n2 {
+						return n1 < n2
+					}
+					continue
+				}
+			}
+		}
+		if sp1 != sp2 {
+			return sp1 < sp2
+		}
+	}
+}
 
-	return nil
+func sortHostlist(hostlist *[]string) {
+	sort.Slice(*hostlist, func(i, j int) bool {
+		return sortHost((*hostlist)[i], (*hostlist)[j])
+	})
 }


### PR DESCRIPTION
Thanks for this implementation of hostlist Steve.

I've put together some changes to sort the expanded list based on it's string and numeric properties.

The string based sorting was producing a list like the following on a componded nodelist: node1-1-[1-11]

```
node1-1-1
node1-1-10
node1-1-11
node1-1-2
node1-1-3
node1-1-4
node1-1-5
node1-1-6
node1-1-7
node1-1-8
node1-1-9
```
With these changes the sorted output will appear as:

```
node1-1-1
node1-1-2
node1-1-3
node1-1-4
node1-1-5
node1-1-6
node1-1-7
node1-1-8
node1-1-9
node1-1-10
node1-1-11
```

Cheers